### PR TITLE
Removed references to old function postprocess dataloader

### DIFF
--- a/daily_dialog/UtterancesDataset.py
+++ b/daily_dialog/UtterancesDataset.py
@@ -171,7 +171,7 @@ class UtterancesDataset(Dataset):
         def collate_fn(items):
             '''
             Pads the context from the left and the response from the right.
-            Makes sure it is batch second.
+            Results in batches with (contexts, responses), with batch-first.
             '''
             assert padding_value != None, "Please provide pad_token_id to use for padding"
             inputs = torch.fliplr(pad_sequence(

--- a/modules/pytorch_lightning/LightingBaseRationalizedLanguageModel.py
+++ b/modules/pytorch_lightning/LightingBaseRationalizedLanguageModel.py
@@ -3,7 +3,6 @@ import pytorch_lightning as pl
 from tokenizers import Tokenizer
 from transformers import AdamW
 
-from misc.old.NextNPredictionDataset import postprocess_dataloader_out
 from utils.utils import fussed_lasso
 
 
@@ -57,7 +56,10 @@ class LightingBaseRationalizedLanguageModel(pl.LightningModule):
         return rational
 
     def batch_out(self, batch):
-        rational_in, targets = postprocess_dataloader_out(batch)
+
+        # Make batch second
+        rational_in = batch[0].permute(1, 0)
+        targets = batch[1].permute(1, 0)
 
         out = self.forward(rational_in, targets)
 

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -3,8 +3,7 @@ from typing import Any
 
 import pytorch_lightning as pl
 from pytorch_lightning import LightningModule
-
-from misc.old.NextNPredictionDataset import postprocess_dataloader_out
+import numpy as np
 
 
 class FinishDialogueCallback(pl.Callback):
@@ -130,15 +129,18 @@ class ChangeInPerplexityCallback(pl.Callback):
         total_diff_perplexity = 0
         if (trainer.current_epoch + 1) % self.every_n_epochs == 0:
 
-            for batch in self.dataloader:
-                context, targets = postprocess_dataloader_out(batch)
+            for (contexts, targets) in self.dataloader:
 
-                context = context.to(pl_module.device)
+                contexts = contexts.to(pl_module.device)
                 targets = targets.to(pl_module.device)
+
+                # Make batch second
+                contexts = contexts.permute(1, 0, )
+                targets = targets.permute(1, 0, )
                 n_targets = targets.shape[0]
 
                 # Get the rational
-                rational = pl_module.get_rational(context)
+                rational = pl_module.get_rational(contexts)
 
                 # Mask n extra tokens (in each rational)
                 masked_input = rational["masked_input"]
@@ -247,15 +249,14 @@ class RationaleAnalysisCallback(pl.Callback):
             n = 0
             abs_averages = 0.0
             rel_averages = 0.0
-            for batch in self.dataloader:
+            for (contexts, _) in self.dataloader:
 
                 # This assumes a batch consists of a list of (context, response) pairs
-                context = torch.tensor([c for (c, _) in batch])
-                context = context.to(pl_module.device)
+                contexts = contexts.to(pl_module.device)
 #                print("Context: ", context)
 
                 # Get the mask
-                rational = pl_module.get_rational(context)
+                rational = pl_module.get_rational(contexts)
                 mask = rational["mask"]
 #                print("Mask: ", mask, mask.size(), len(mask[0]))
 


### PR DESCRIPTION
Dataloader provides batches with (responses, targets) with batch-first format.
In several places, functions expect batch-second input. References to 'postprocess_dataloader' are removed. Where necessary, I have permuted the contexts and responses.